### PR TITLE
Fix various bugs

### DIFF
--- a/src/main/java/net/minestom/arena/SimpleCommands.java
+++ b/src/main/java/net/minestom/arena/SimpleCommands.java
@@ -2,6 +2,7 @@ package net.minestom.arena;
 
 import net.minestom.arena.config.ConfigHandler;
 import net.minestom.arena.game.ArenaManager;
+import net.minestom.arena.group.GroupManager;
 import net.minestom.arena.utils.CommandUtils;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.ConsoleSender;
@@ -39,6 +40,7 @@ final class SimpleCommands {
             final Player player = (Player) sender;
             player.setInstance(Lobby.INSTANCE);
             player.setHealth(player.getMaxHealth());
+            GroupManager.removePlayer(player);
         });
 
         final Command reload = new Command("reload");

--- a/src/main/java/net/minestom/arena/game/mob/BlazeMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/BlazeMob.java
@@ -29,7 +29,7 @@ final class BlazeMob extends ArenaMob {
 
         addAIGroup(
                 List.of(rangedAttackGoal),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
     }
     @Override

--- a/src/main/java/net/minestom/arena/game/mob/EndermanMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/EndermanMob.java
@@ -24,7 +24,7 @@ final class EndermanMob extends ArenaMob {
                         new TeleportGoal(this, Duration.ofSeconds(10), 8),
                         new MeleeAttackGoal(this, 1.2, 20, TimeUnit.SERVER_TICK)
                 ),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
         getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(getAttributeValue(Attribute.MOVEMENT_SPEED) * 2);
     }

--- a/src/main/java/net/minestom/arena/game/mob/EvokerMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/EvokerMob.java
@@ -40,7 +40,7 @@ final class EvokerMob extends ArenaMob {
                             ArenaMob silverfish = new ArenaMinion(EntityType.SILVERFISH, this);
                             silverfish.addAIGroup(
                                     List.of(new MeleeAttackGoal(silverfish, 1.2, 20, TimeUnit.SERVER_TICK)),
-                                    List.of(new ClosestEntityTarget(silverfish, 32, Player.class))
+                                    List.of(new ClosestEntityTarget(silverfish, 32, entity -> entity instanceof Player))
                             );
                             silverfish.getAttribute(Attribute.MAX_HEALTH).setBaseValue(silverfish.getMaxHealth() / 4);
                             silverfish.heal();
@@ -58,7 +58,7 @@ final class EvokerMob extends ArenaMob {
                         ((EvokerMeta) getEntityMeta()).setSpell(SpellcasterIllagerMeta.Spell.NONE);
                     }, TaskSchedule.seconds(2), TaskSchedule.stop());
                 })),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
     }
 
@@ -77,7 +77,7 @@ final class EvokerMob extends ArenaMob {
         @Override
         public boolean shouldStart() {
             Entity target = entityCreature.getTarget();
-            if (target == null) target = findTarget();
+            if (target == null || target.getInstance() != entityCreature.getInstance()) target = findTarget();
             if (target == null) return false;
             if (Cooldown.hasCooldown(System.currentTimeMillis(), lastSummon, cooldown)) return false;
             this.target = target;

--- a/src/main/java/net/minestom/arena/game/mob/SkeletonMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/SkeletonMob.java
@@ -32,7 +32,7 @@ final class SkeletonMob extends ArenaMob {
 
         addAIGroup(
                 List.of(rangedAttackGoal),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
     }
 

--- a/src/main/java/net/minestom/arena/game/mob/SpiderMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/SpiderMob.java
@@ -38,7 +38,7 @@ final class SpiderMob extends ArenaMob {
 
         addAIGroup(
                 List.of(attackGoal),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
     }
 

--- a/src/main/java/net/minestom/arena/game/mob/ZombieMob.java
+++ b/src/main/java/net/minestom/arena/game/mob/ZombieMob.java
@@ -16,7 +16,7 @@ final class ZombieMob extends ArenaMob {
         super(EntityType.ZOMBIE, context);
         addAIGroup(
                 List.of(new MeleeAttackGoal(this, 1.2, 20, TimeUnit.SERVER_TICK)),
-                List.of(new ClosestEntityTarget(this, 32, Player.class))
+                List.of(new ClosestEntityTarget(this, 32, entity -> entity instanceof Player))
         );
 
         boolean isBaby = context.stage() >= 5 && ThreadLocalRandom.current().nextBoolean();

--- a/src/main/java/net/minestom/arena/group/Group.java
+++ b/src/main/java/net/minestom/arena/group/Group.java
@@ -6,6 +6,7 @@ import net.minestom.arena.group.displays.GroupDisplay;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Set;
 
 public sealed interface Group extends ForwardingAudience permits GroupImpl {
@@ -15,7 +16,7 @@ public sealed interface Group extends ForwardingAudience permits GroupImpl {
 
     @NotNull Player leader();
 
-    @NotNull Set<@NotNull Player> members();
+    @NotNull List<@NotNull Player> members();
 
     @NotNull GroupDisplay display();
 

--- a/src/main/java/net/minestom/arena/group/GroupCommand.java
+++ b/src/main/java/net/minestom/arena/group/GroupCommand.java
@@ -87,10 +87,10 @@ public final class GroupCommand extends Command {
                 if (group == null) {
                     GroupManager.getGroup(newLeader);
                     Messenger.info(sender, "Group created");
-                } else if (group.leader() == newLeader) {
-                    Messenger.warn(sender, "You are already the leader");
                 } else if (group.leader() != player) {
                     Messenger.warn(sender, "You are not the leader of this group");
+                } else if (group.leader() == newLeader) {
+                    Messenger.warn(sender, "You are already the leader");
                 } else {
                     group.setLeader(newLeader);
                 }
@@ -153,7 +153,7 @@ public final class GroupCommand extends Command {
                     GroupManager.removePlayer(invitee); // Remove from old group
                     group.addMember(invitee);
                     Component accepted = group.getAcceptedMessage();
-                    invitee.sendMessage(accepted);
+                    Messenger.info(invitee, accepted);
                 } else if (group.members().contains(invitee)) {
                     Messenger.warn(invitee, "You are already in this group");
                 } else {

--- a/src/main/java/net/minestom/arena/group/GroupImpl.java
+++ b/src/main/java/net/minestom/arena/group/GroupImpl.java
@@ -8,13 +8,14 @@ import net.minestom.arena.group.displays.GroupDisplay;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
 
 final class GroupImpl implements Group {
-    private final Set<Player> players = new HashSet<>();
+    private final List<Player> players = new ArrayList<>();
     private final Set<Player> pendingInvites = Collections.newSetFromMap(new WeakHashMap<>());
 
     private Player leader;
@@ -31,8 +32,8 @@ final class GroupImpl implements Group {
     }
 
     @Override
-    public @NotNull Set<Player> members() {
-        return Set.copyOf(players);
+    public @NotNull List<Player> members() {
+        return List.copyOf(players);
     }
 
     @Override
@@ -58,7 +59,11 @@ final class GroupImpl implements Group {
     public void addMember(@NotNull Player player) {
         if (players.add(player)) {
             pendingInvites.remove(player);
-            players.forEach(p -> Messenger.info(p, player.getName().append(Component.text(" has joined your group"))));
+            players.forEach(p -> {
+                if (p != player) {
+                    Messenger.info(p, player.getName().append(Component.text(" has joined your group")));
+                }
+            });
             display.update();
         }
     }

--- a/src/main/java/net/minestom/arena/group/GroupManager.java
+++ b/src/main/java/net/minestom/arena/group/GroupManager.java
@@ -1,5 +1,6 @@
 package net.minestom.arena.group;
 
+import net.minestom.arena.LobbySidebarDisplay;
 import net.minestom.arena.Messenger;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +20,7 @@ public final class GroupManager {
 
     public static @NotNull GroupImpl createGroup(@NotNull Player player) {
         GroupImpl group = new GroupImpl(player);
+        group.setDisplay(new LobbySidebarDisplay(group));
         groups.put(player, group);
         return group;
     }

--- a/src/main/java/net/minestom/arena/group/GroupManager.java
+++ b/src/main/java/net/minestom/arena/group/GroupManager.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-final class GroupManager {
+public final class GroupManager {
     private static final Map<Player, GroupImpl> groups = new HashMap<>();
 
     public static @NotNull GroupImpl getGroup(@NotNull Player player) {

--- a/src/main/java/net/minestom/arena/group/displays/GroupSidebarDisplay.java
+++ b/src/main/java/net/minestom/arena/group/displays/GroupSidebarDisplay.java
@@ -1,6 +1,8 @@
 package net.minestom.arena.group.displays;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minestom.arena.Messenger;
 import net.minestom.arena.group.Group;
 import net.minestom.server.entity.Player;
 import net.minestom.server.scoreboard.Sidebar;
@@ -11,6 +13,8 @@ import java.util.List;
 import java.util.Set;
 
 public abstract class GroupSidebarDisplay implements GroupDisplay {
+    private static final int MAX_SCOREBOARD_LINES = 15;
+
     private final Sidebar sidebar = new Sidebar(Component.text("Group"));
     private final Group group;
 
@@ -20,8 +24,22 @@ public abstract class GroupSidebarDisplay implements GroupDisplay {
 
     private List<Sidebar.ScoreboardLine> createLines() {
         List<Sidebar.ScoreboardLine> lines = new ArrayList<>();
-        for (Player player : group.members()) {
-            lines.add(createPlayerLine(player, group));
+
+        List<Player> groupMembers = group.members();
+        // separate check is required to prevent "1 more..." from occurring when the player could just be displayed.
+        if (groupMembers.size() <= MAX_SCOREBOARD_LINES) {
+            for (Player player : groupMembers) {
+                lines.add(createPlayerLine(player, group));
+            }
+        } else {
+            for (int i = 0; i < groupMembers.size() && i < 14; i++) {
+                lines.add(createPlayerLine(groupMembers.get(i), group));
+            }
+            lines.add(new Sidebar.ScoreboardLine(
+                    "more",
+                    Component.text(groupMembers.size() - 14 + " more...", NamedTextColor.DARK_GREEN),
+                    -1
+            ));
         }
 
         lines.addAll(createAdditionalLines());


### PR DESCRIPTION
- [x] Fix evoker looking at players in a different instance (resolves #50)
- [x] Update AI methods to not use their deprecated counterparts
- [x] If you leave during round start countdown, you still receive the countdown/items/armour
- [x] If you disband/are not in a group then create a new group you don't have the scoreboard/sidebar
- [x] Confusing messages when setting another player to group leader and you aren't the leader
- [x] Make the process for joining a group when you have an existing group less spammy
- [x] If the size of a group is > 16, the scoreboard lines will go over the max and cause errors. Replace this with a `... 5 more`