### PR TITLE
Improve improved healthcare

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.Minestom:Minestom:eb06ba8664")
+    implementation("com.github.Minestom:Minestom:9abb3079f6")
     implementation("de.articdive:jnoise-pipeline:4.0.0")
     implementation("io.prometheus:simpleclient:0.16.0")
     implementation("io.prometheus:simpleclient_hotspot:0.16.0")

--- a/src/main/java/net/minestom/arena/game/mob/MobArena.java
+++ b/src/main/java/net/minestom/arena/game/mob/MobArena.java
@@ -135,7 +135,7 @@ public final class MobArena implements SingleInstanceArena {
                             attribute.removeModifier(modifier);
                         }
                         player.heal();
-                    }, level -> "Currently gives " + level * 2 + " extra hearts and heals " + level + " extra heart" + (level == 1 ? "" : "s") + ".",
+                    }, level -> "Currently gives " + level * 2 + " extra hearts and heals " + level + " extra heart" + (level == 1 ? "" : "s"),
                     10, 1.3f, 5),
             new ArenaUpgrade("Combat Training", "All physical attacks deal 10% more damage",
                     TextColor.color(0xff5c3c), Material.IRON_SWORD, (player, count) -> {

--- a/src/main/java/net/minestom/arena/game/mob/MobArena.java
+++ b/src/main/java/net/minestom/arena/game/mob/MobArena.java
@@ -119,7 +119,7 @@ public final class MobArena implements SingleInstanceArena {
     private static final UUID COMBAT_TRAINING_UUID = new UUID(24539786, 23945687);
 
     public static final List<ArenaUpgrade> UPGRADES = List.of(
-            new ArenaUpgrade("Improved Healthcare", "Increases max health by two heart.",
+            new ArenaUpgrade("Improved Healthcare", "Increases max health by two hearts, and healing by one heart.",
                     TextColor.color(0x63ff52), Material.POTION, (player, count) -> {
                         final AttributeModifier modifier = new AttributeModifier(
                                 HEALTHCARE_UUID, "mobarena-healthcare", 4 * count,
@@ -135,7 +135,7 @@ public final class MobArena implements SingleInstanceArena {
                             attribute.removeModifier(modifier);
                         }
                         player.heal();
-                    }, level -> "Currently gives " + level * 2 + " extra hearts",
+                    }, level -> "Currently gives " + level * 2 + " extra hearts and heals " + level + " extra heart" + (level == 1 ? "" : "s") + ".",
                     10, 1.3f, 5),
             new ArenaUpgrade("Combat Training", "All physical attacks deal 10% more damage",
                     TextColor.color(0xff5c3c), Material.IRON_SWORD, (player, count) -> {
@@ -450,7 +450,7 @@ public final class MobArena implements SingleInstanceArena {
         }
 
         for (Player member : group.members()) {
-            member.setHealth(member.getHealth() + 4); // Heal 2 hearts
+            member.setHealth(member.getHealth() + 4 + (getUpgrade(UPGRADES.get(0)) * 2)); // Heal 2 hearts + 1 heart for each healthcare level
             playerClass(member).apply(member);
         }
 

--- a/src/main/java/net/minestom/arena/game/mob/MobArena.java
+++ b/src/main/java/net/minestom/arena/game/mob/MobArena.java
@@ -119,7 +119,7 @@ public final class MobArena implements SingleInstanceArena {
     private static final UUID COMBAT_TRAINING_UUID = new UUID(24539786, 23945687);
 
     public static final List<ArenaUpgrade> UPGRADES = List.of(
-            new ArenaUpgrade("Improved Healthcare", "Increases max health by two hearts, and healing by one heart.",
+            new ArenaUpgrade("Improved Healthcare", "Increases max health by two hearts per level, and healing by one heart if you have the upgrade.",
                     TextColor.color(0x63ff52), Material.POTION, (player, count) -> {
                         final AttributeModifier modifier = new AttributeModifier(
                                 HEALTHCARE_UUID, "mobarena-healthcare", 4 * count,
@@ -135,7 +135,7 @@ public final class MobArena implements SingleInstanceArena {
                             attribute.removeModifier(modifier);
                         }
                         player.heal();
-                    }, level -> "Currently gives " + level * 2 + " extra hearts and heals " + level + " extra heart" + (level == 1 ? "" : "s"),
+                    }, level -> "Currently gives " + level * 2 + " extra hearts" + (level > 0 ? " and heals an extra heart" : ""),
                     10, 1.3f, 5),
             new ArenaUpgrade("Combat Training", "All physical attacks deal 10% more damage",
                     TextColor.color(0xff5c3c), Material.IRON_SWORD, (player, count) -> {
@@ -450,7 +450,7 @@ public final class MobArena implements SingleInstanceArena {
         }
 
         for (Player member : group.members()) {
-            member.setHealth(member.getHealth() + 4 + (getUpgrade(UPGRADES.get(0)) * 2)); // Heal 2 hearts + 1 heart for each healthcare level
+            member.setHealth(member.getHealth() + (getUpgrade(UPGRADES.get(0)) > 0 ? 6 : 4)); // Heal 2 hearts + 1 heart if you have improved healthcare
             playerClass(member).apply(member);
         }
 


### PR DESCRIPTION
**The Issue**

Improved healthcare simply adds 2 hearts per level. The upgrade is useless if you don't no-hit right after you get it, or you have full health when you get it.

**My Solution**

Improved healthcare now also heals 1 heart per level. This allows for up to 7 hearts healed per round. It also allows you to survive longer in the game without a group.